### PR TITLE
Memory leak

### DIFF
--- a/crypto/asn1/asn_moid.c
+++ b/crypto/asn1/asn_moid.c
@@ -101,5 +101,6 @@ static int do_create(const char *value, const char *name)
         oid->ln = lntmp;
     }
 
+    OPENSSL_free(lntmp);
     return 1;
 }


### PR DESCRIPTION
lntmp variable is never freed causing a memory leak